### PR TITLE
Add AI usage guidance and improve README for candidates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -396,3 +396,6 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+
+# AI tooling (local only, not for candidates)
+CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -1,25 +1,43 @@
-﻿<img src="./images/iDHL-DarkBlue.svg" alt="IDHL Logo" title="IDHL" width="90">
+<img src="./images/iDHL-DarkBlue.svg" alt="IDHL Logo" title="IDHL" width="90">
 
 # .NET Developer Assessment
 
 ## Overview
 
-You are tasked with creating a blog post page using the [provided solution](./DeveloperAssessment.sln), which is a slightly modified version of the default MVC .NET template.
+You are tasked with creating a blog post page using the [provided solution](./DeveloperAssessment.sln), which is a slightly modified version of the default ASP.NET Core MVC template targeting .NET 8.
+
+## Prerequisites
+
+- [.NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8.0)
 
 ## Assessments
 
-We have two assessments designed for different skill levels: one for junior developers and another for intermediate developers. Please select the appropriate markdown file based on the role you are applying for:
+We have two assessments designed for different skill levels. Please select the one for the role you are applying for:
 
 - [Junior Developer Assessment](./docs/JuniorDevAssessment.md)
 - [Intermediate Developer Assessment](./docs/IntermediateDevAssessment.md)
 
 ## Provided Resources
 
-- [HTML Template](./assets/template.html)
-- [Mock Data](./assets/Blog-Posts.json)
+- [HTML Template](./assets/template.html) — a pre-built Bootstrap page layout to base your views on, with placeholder comments marking where content should be inserted
+- [Mock Data](./assets/Blog-Posts.json) — blog post data including content and comments, to be moved into the project and used as your data source
+
+## Use of AI
+
+You are welcome to use AI tools (such as GitHub Copilot, ChatGPT, Claude, Cursor, etc.) during this assessment.
+
+As you work, keep brief notes on how you used AI — which tools, what you prompted it to do, where it was helpful, and where it fell short. You don't need to produce a formal write-up, but having a short section in your repository's README or a commit history that reflects your process will be useful.
+
+We'll discuss your use of AI in the interview, including:
+
+- Which tools you used and for which parts of the task
+- Example prompts you wrote — what worked well and what didn't
+- Where the AI output was wrong or unhelpful, and how you identified and corrected it
+- Anything you deliberately chose to write yourself rather than use AI for, and why
+- Whether AI influenced any structural or architectural decisions — and whether in hindsight you stand behind them
+
+This isn't a test of whether you used AI — it's a way to understand how you work with it. Being honest and reflective will always be viewed positively.
 
 ## Delivery Instructions
-
-Ensure your solution is well-organised and follows best practices.
 
 Submit your completed solution via a GitHub repository.


### PR DESCRIPTION
- Add Use of AI section to README covering permitted tools, written record encouragement, and interview discussion points
- Expand README with Prerequisites section and resource descriptions
- Add CLAUDE.md to .gitignore (local AI tooling, not for candidates)